### PR TITLE
Add basic struture files.

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,0 +1,2 @@
+Dylan Vaughn <dylancvaughn@gmail.com>
+Adam Burns <adam@operatingops.org>

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,2 +1,2 @@
-Dylan Vaughn <dylancvaughn@gmail.com>
-Adam Burns <adam@operatingops.org>
+Dylan Vaughn <dylan@ordinaryexperts.com>
+Adam Burns <adam@ordinaryexperts.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Unreleased

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing
+
+This project follows the [Ubuntu Code of Conduct v2.0][conduct]. Thanks Ubuntu!
+
+This guide based on the one in [factory_girl_rails v4.8.0][source]. Thanks Thoughtbot!
+
+## Code
+
+1. [Fork and clone the repo][fork].
+
+1. Create a feature branch:
+
+   ```shell
+   git checkout -b feature/my_feature
+   ```
+
+1. Make your change.
+
+1. Update `CHANGELOG.md`.
+
+1. Push to your fork.
+
+   ```shell
+   git push origin feature/my_feature
+   ```
+
+1. [Create a Pull Request][pr].
+
+At this point you're waiting on us. Remember, you get the SLA you pay for and we don't get paid so we might not respond right away. We look for the right fix over a quick fix, and we may suggest some changes or improvements or alternatives.
+
+To increase the chance that your pull request gets accepted:
+
+* Follow [Simple Style][style].
+* Write [good commit messages][commits].
+* Organize your commits. "Fix typo" and "work in progress" commits are hard to follow. If you like to commit often, check out git's [rebase][rebase]. You can use it to clean up at the end.
+
+## Issues
+
+The issue tracker is for project changes. Bugfixes, improvements, etc. If you need help, check out [ordinaryexperts.com][home] instead of submitting an issue.
+
+Write everything you know. Think of the questions we might ask and write the answers. Some great things to include:
+
+  1. What you expected to happen, and why.
+  2. What happened that was different from your expectations, and why, if you have any theories.
+  3. Whether or not you can contribute a fix.
+
+Like for pull requests, remember that we don't get paid so there's no SLA. We'll respond quickly if we can, though.
+
+[conduct]: https://www.ubuntu.com/about/about-ubuntu/conduct
+[commits]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+[fork]: https://help.github.com/articles/fork-a-repo/
+[home]: http://ordinaryexperts.com/
+[pr]: https://help.github.com/articles/creating-a-pull-request/
+[rebase]: https://help.github.com/articles/about-git-rebase/
+[source]: https://github.com/thoughtbot/factory_girl_rails/blob/v4.8.0/CONTRIBUTING.md
+[style]: https://github.com/operatingops/simple_style/blob/v0.1.1/SIMPLE_STYLE.md

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Robomakery, Inc. DBA Ordinary Experts
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# About
+
+Infrastructure automation for the Ordinary Experts website.


### PR DESCRIPTION
Adds authors list, changelog, contributing guide, license, and readme.

@dylanvaughn I based this on what I use in my own OSS projects but I updated the branch name examples to use the 'feature/' pattern and I switched my home page URL to the Ordinary Experts one. I also set the copyright to OE instead of an individual.